### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/327/15/85632715.geojson
+++ b/data/856/327/15/85632715.geojson
@@ -897,6 +897,10 @@
     },
     "wof:country":"AQ",
     "wof:country_alpha3":"ATA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"ca83b481ddb7e25b51fafa797ec70dec",
     "wof:hierarchy":[
         {
@@ -905,7 +909,7 @@
         }
     ],
     "wof:id":85632715,
-    "wof:lastmodified":1566587520,
+    "wof:lastmodified":1582356321,
     "wof:name":"Antarctica",
     "wof:parent_id":102191579,
     "wof:placetype":"country",

--- a/data/890/418/557/890418557.geojson
+++ b/data/890/418/557/890418557.geojson
@@ -250,6 +250,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469051252,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e4bab7122e93c6cf98aac328b9d50fd8",
     "wof:hierarchy":[
         {
@@ -260,7 +263,7 @@
         }
     ],
     "wof:id":890418557,
-    "wof:lastmodified":1561792316,
+    "wof:lastmodified":1582356323,
     "wof:name":"McMurdo Station",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/421/517/890421517.geojson
+++ b/data/890/421/517/890421517.geojson
@@ -213,6 +213,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469051396,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"e3417346484720ead5424c2d0094e7fb",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":890421517,
-    "wof:lastmodified":1566587522,
+    "wof:lastmodified":1582356322,
     "wof:name":"Dumont d'Urville Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/421/521/890421521.geojson
+++ b/data/890/421/521/890421521.geojson
@@ -213,6 +213,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469051396,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9db20605e323842899377923dc0931c5",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
         }
     ],
     "wof:id":890421521,
-    "wof:lastmodified":1566587523,
+    "wof:lastmodified":1582356322,
     "wof:name":"Halley Research Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/319/890435319.geojson
+++ b/data/890/435/319/890435319.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469052063,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"501d742c503a843acbe0ddc1754d01fa",
     "wof:hierarchy":[
         {
@@ -212,7 +215,7 @@
         }
     ],
     "wof:id":890435319,
-    "wof:lastmodified":1566587524,
+    "wof:lastmodified":1582356323,
     "wof:name":"Novolazarevskaya Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/329/890435329.geojson
+++ b/data/890/435/329/890435329.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469052063,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"cc01e6c34f41af9dcb4c0fd0f35437d3",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":890435329,
-    "wof:lastmodified":1566587524,
+    "wof:lastmodified":1582356323,
     "wof:name":"Palmer Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/033/890442033.geojson
+++ b/data/890/442/033/890442033.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"AQ",
     "wof:created":1469052348,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"54cdf50adceb1ccb8f974872ae2eeb59",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":890442033,
-    "wof:lastmodified":1566587523,
+    "wof:lastmodified":1582356323,
     "wof:name":"Scott Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.