### PR TITLE
Name updates

### DIFF
--- a/data/856/327/15/85632715.geojson
+++ b/data/856/327/15/85632715.geojson
@@ -33,6 +33,9 @@
     "name:afr_x_preferred":[
         "Antarktika"
     ],
+    "name:afr_x_variant":[
+        "Antarktiese verdragsgebied"
+    ],
     "name:als_x_preferred":[
         "Antarktika"
     ],
@@ -243,6 +246,9 @@
     "name:gan_x_preferred":[
         "\u5357\u6975\u6d32"
     ],
+    "name:gan_x_variant":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
+    ],
     "name:gla_x_preferred":[
         "Antargtaga"
     ],
@@ -339,6 +345,9 @@
     "name:isl_x_preferred":[
         "Su\u00f0urskautslandi\u00f0"
     ],
+    "name:isl_x_variant":[
+        "Antarctic s\u00e1ttm\u00e1lasv\u00e6\u00f0i\u00f0"
+    ],
     "name:ita_x_preferred":[
         "Antartide"
     ],
@@ -354,6 +363,9 @@
     "name:jpn_x_preferred":[
         "\u5357\u6975",
         "\u5357\u6975\u5927\u9678"
+    ],
+    "name:jpn_x_variant":[
+        "\u5357\u6975\u6761\u7d04\u30a8\u30ea\u30a2"
     ],
     "name:kaa_x_preferred":[
         "Antarktika"
@@ -446,6 +458,9 @@
     "name:ltz_x_preferred":[
         "Antarktis"
     ],
+    "name:lzh_x_preferred":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
+    ],
     "name:mai_x_preferred":[
         "\u0905\u0902\u091f\u093e\u0930\u094d\u0915\u091f\u093f\u0915\u093e"
     ],
@@ -511,6 +526,9 @@
     ],
     "name:nno_x_preferred":[
         "Antarktis"
+    ],
+    "name:nno_x_variant":[
+        "Antarktis traktat-omr\u00e5de"
     ],
     "name:nob_x_preferred":[
         "Antarktis"
@@ -691,7 +709,8 @@
         "\u0e17\u0e27\u0e35\u0e1b\u0e41\u0e2d\u0e19\u0e15\u0e32\u0e23\u0e4c\u0e01\u0e15\u0e34\u0e01\u0e32"
     ],
     "name:tha_x_variant":[
-        "\u0e41\u0e2d\u0e19\u0e15\u0e32\u0e23\u0e4c\u0e01\u0e15\u0e34\u0e01\u0e32"
+        "\u0e41\u0e2d\u0e19\u0e15\u0e32\u0e23\u0e4c\u0e01\u0e15\u0e34\u0e01\u0e32",
+        "\u0e1e\u0e37\u0e49\u0e19\u0e17\u0e35\u0e48\u0e2a\u0e19\u0e18\u0e34\u0e2a\u0e31\u0e0d\u0e0d\u0e32\u0e41\u0e2d\u0e19\u0e15\u0e32\u0e23\u0e4c\u0e01\u0e15\u0e34\u0e01"
     ],
     "name:tir_x_preferred":[
         "\u12a0\u1295\u1273\u122d\u12ad\u1272\u12ab"
@@ -747,6 +766,9 @@
     "name:wuu_x_preferred":[
         "\u5357\u6975\u6d32"
     ],
+    "name:wuu_x_variant":[
+        "\u5357\u6781\u6761\u7ea6\u5730\u533a"
+    ],
     "name:xal_x_preferred":[
         "\u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u043a"
     ],
@@ -759,20 +781,42 @@
     "name:yor_x_preferred":[
         "Ant\u00e1rkt\u00eck\u00e0"
     ],
+    "name:yue_x_preferred":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
+    ],
     "name:zea_x_preferred":[
         "Antartica"
     ],
     "name:zha_x_preferred":[
         "Namzgigcouh"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5357\u6781\u6761\u7ea6\u5730\u533a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
+    ],
     "name:zho_min_nan_x_preferred":[
         "L\u00e2m-ke\u030dk T\u0101i-lio\u030dk"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5357\u6781\u6761\u7ea6\u5730\u533a"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5357\u6781\u6761\u7ea6\u5730\u533a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5357\u6975\u689d\u7d04\u5730\u5340"
     ],
     "name:zho_x_preferred":[
         "\u5357\u6781\u6d32"
     ],
     "name:zho_x_variant":[
-        "\u5357\u6975\u6d32"
+        "\u5357\u6975\u6d32",
+        "\u5357\u6781\u6761\u7ea6\u5730\u533a"
     ],
     "name:zho_yue_x_preferred":[
         "\u5357\u6975\u6d32"
@@ -910,7 +954,7 @@
         }
     ],
     "wof:id":85632715,
-    "wof:lastmodified":1583797276,
+    "wof:lastmodified":1587427743,
     "wof:name":"Antarctica",
     "wof:parent_id":102191579,
     "wof:placetype":"country",

--- a/data/890/421/517/890421517.geojson
+++ b/data/890/421/517/890421517.geojson
@@ -91,6 +91,9 @@
     "name:swe_x_preferred":[
         "Dumont d'Urville"
     ],
+    "name:tur_x_preferred":[
+        "Dumont d'Urville \u0130stasyonu"
+    ],
     "name:ukr_x_preferred":[
         "\u0414\u044e\u043c\u043e\u043d \u0414\u044e\u0440\u0432\u0456\u043b\u044c"
     ],
@@ -224,7 +227,7 @@
         }
     ],
     "wof:id":890421517,
-    "wof:lastmodified":1582356322,
+    "wof:lastmodified":1587427744,
     "wof:name":"Dumont d'Urville Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/329/890435329.geojson
+++ b/data/890/435/329/890435329.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":4.0,
+    "name:cat_x_preferred":[
+        "Base Palmer"
+    ],
     "name:ceb_x_preferred":[
         "Palmer Station"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:fra_x_variant":[
         "base antarctique Palmer"
+    ],
+    "name:heb_x_preferred":[
+        "\u05ea\u05d7\u05e0\u05ea \u05e4\u05d0\u05dc\u05de\u05e8"
     ],
     "name:ita_x_preferred":[
         "stazione Palmer"
@@ -206,7 +212,7 @@
         }
     ],
     "wof:id":890435329,
-    "wof:lastmodified":1582356323,
+    "wof:lastmodified":1587427745,
     "wof:name":"Palmer Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.