### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/577/140/3/1125771403.geojson
+++ b/data/112/577/140/3/1125771403.geojson
@@ -31,6 +31,9 @@
     "name:aze_x_preferred":[
         "Vostok"
     ],
+    "name:bel_x_preferred":[
+        "\u0423\u0441\u0445\u043e\u0434"
+    ],
     "name:bos_x_preferred":[
         "Stanica Vostok"
     ],
@@ -76,6 +79,9 @@
     "name:heb_x_preferred":[
         "\u05d5\u05d5\u05e1\u05d8\u05d5\u05e7"
     ],
+    "name:hye_x_preferred":[
+        "\u054e\u0578\u057d\u057f\u0578\u056f \u0563\u056b\u057f\u0561\u056f\u0561\u0575\u0561\u0576"
+    ],
     "name:ind_x_preferred":[
         "Stasiun Vostok"
     ],
@@ -103,6 +109,9 @@
     "name:mal_x_preferred":[
         "\u0d35\u0d4b\u0d38\u0d4d\u0d1f\u0d4b\u0d15\u0d4d \u0d38\u0d4d\u0d31\u0d4d\u0d31\u0d47\u0d37\u0d7b"
     ],
+    "name:mkd_x_preferred":[
+        "\u0412\u043e\u0441\u0442\u043e\u043a"
+    ],
     "name:mwl_x_preferred":[
         "Vostok"
     ],
@@ -120,6 +129,9 @@
     ],
     "name:nor_x_variant":[
         "Vostok"
+    ],
+    "name:oci_x_preferred":[
+        "Basa antartica Vostok"
     ],
     "name:pol_x_preferred":[
         "Wostok"
@@ -147,6 +159,9 @@
     ],
     "name:swe_x_preferred":[
         "Vostok"
+    ],
+    "name:tat_x_preferred":[
+        "\u0412\u043e\u0441\u0442\u043e\u043a"
     ],
     "name:tha_x_preferred":[
         "\u0e2a\u0e16\u0e32\u0e19\u0e35\u0e27\u0e2d\u0e2a\u0e15\u0e2d\u0e04"
@@ -202,7 +217,7 @@
         }
     ],
     "wof:id":1125771403,
-    "wof:lastmodified":1566587525,
+    "wof:lastmodified":1690850372,
     "wof:name":"Vostok Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/578/713/5/1125787135.geojson
+++ b/data/112/578/713/5/1125787135.geojson
@@ -37,6 +37,9 @@
     "name:fin_x_preferred":[
         "Mizuho"
     ],
+    "name:fra_x_preferred":[
+        "Base antarctique Mizuho"
+    ],
     "name:ita_x_preferred":[
         "Stazione Mizuho"
     ],
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":1125787135,
-    "wof:lastmodified":1566587524,
+    "wof:lastmodified":1690850371,
     "wof:name":"Mizuho Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/578/715/9/1125787159.geojson
+++ b/data/112/578/715/9/1125787159.geojson
@@ -25,6 +25,9 @@
     "name:ast_x_preferred":[
         "Base SANAE IV"
     ],
+    "name:ast_x_variant":[
+        "Base SANAE"
+    ],
     "name:deu_x_preferred":[
         "SANAE-IV-Station"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:spa_x_preferred":[
         "Base SANAE IV"
+    ],
+    "name:spa_x_variant":[
+        "Base SANAE"
     ],
     "name:und_x_variant":[
         "SANAE"
@@ -94,7 +100,7 @@
         }
     ],
     "wof:id":1125787159,
-    "wof:lastmodified":1566587525,
+    "wof:lastmodified":1690850371,
     "wof:name":"SANAE IV",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/423/3/1125904233.geojson
+++ b/data/112/590/423/3/1125904233.geojson
@@ -82,6 +82,9 @@
     "name:lav_x_preferred":[
         "Artigasa"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u0410\u0440\u0442\u0438\u0433\u0430\u0441\u201c"
+    ],
     "name:nld_x_preferred":[
         "Artigas-basis"
     ],
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":1125904233,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850370,
     "wof:name":"Artigas Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/498/7/1125904987.geojson
+++ b/data/112/590/498/7/1125904987.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:afr_x_preferred":[
+        "Esperanza-basis"
+    ],
+    "name:ara_x_preferred":[
+        "\u0642\u0627\u0639\u062f\u0629 \u0627\u064a\u0633\u0628\u064a\u0631\u0627\u0646\u0632\u0627"
+    ],
+    "name:aze_x_preferred":[
+        "Esperansa stansiyas\u0131"
+    ],
     "name:ceb_x_preferred":[
         "Esperanza Base"
     ],
@@ -39,6 +48,9 @@
     ],
     "name:eng_x_variant":[
         "Esperanza Base"
+    ],
+    "name:epo_x_preferred":[
+        "Bazo Esperanza"
     ],
     "name:eus_x_preferred":[
         "Esperanza basea"
@@ -69,6 +81,12 @@
     ],
     "name:lav_x_preferred":[
         "Esperansa"
+    ],
+    "name:lit_x_preferred":[
+        "Esperansos baz\u0117"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u0415\u0441\u043f\u0435\u0440\u0430\u043d\u0446\u0430"
     ],
     "name:msa_x_preferred":[
         "Pangkalan Esperanza"
@@ -102,6 +120,9 @@
     ],
     "name:swe_x_preferred":[
         "Esperanza"
+    ],
+    "name:tur_x_preferred":[
+        "Esperanza \u00dcss\u00fc"
     ],
     "name:ukr_x_preferred":[
         "\u0415\u0441\u043f\u0435\u0440\u0430\u043d\u0441\u0430"
@@ -142,7 +163,7 @@
         }
     ],
     "wof:id":1125904987,
-    "wof:lastmodified":1566587524,
+    "wof:lastmodified":1690850370,
     "wof:name":"Esperanza Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/590/501/9/1125905019.geojson
+++ b/data/112/590/501/9/1125905019.geojson
@@ -52,6 +52,9 @@
     "name:eng_x_variant":[
         "Mirny Station"
     ],
+    "name:est_x_preferred":[
+        "Mirn\u00f5i polaarjaam"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0633\u062a\u06af\u0627\u0647 \u0645\u06cc\u0631\u0646\u06cc"
     ],
@@ -91,6 +94,9 @@
     "name:lav_x_preferred":[
         "Mirnija"
     ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0438\u0440\u043d\u0438"
+    ],
     "name:nld_x_preferred":[
         "Mirniy"
     ],
@@ -126,6 +132,9 @@
     ],
     "name:swe_x_preferred":[
         "Mirnyj"
+    ],
+    "name:tur_x_preferred":[
+        "Mirn\u0131y \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u041c\u0438\u0440\u043d\u0438\u0439"
@@ -172,7 +181,7 @@
         }
     ],
     "wof:id":1125905019,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850371,
     "wof:name":"Mirny Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/597/822/1/1125978221.geojson
+++ b/data/112/597/822/1/1125978221.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Base Troll"
+    ],
     "name:cat_x_preferred":[
         "Base Troll"
     ],
@@ -41,6 +44,9 @@
         "Troll research station",
         "Troll"
     ],
+    "name:eus_x_preferred":[
+        "Troll basea"
+    ],
     "name:fin_x_preferred":[
         "Troll"
     ],
@@ -58,6 +64,9 @@
     ],
     "name:lav_x_preferred":[
         "Trolla"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0422\u0440\u043e\u043b"
     ],
     "name:nld_x_preferred":[
         "Troll"
@@ -129,7 +138,7 @@
         }
     ],
     "wof:id":1125978221,
-    "wof:lastmodified":1566587524,
+    "wof:lastmodified":1690850371,
     "wof:name":"Troll research station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/839/5/1141908395.geojson
+++ b/data/114/190/839/5/1141908395.geojson
@@ -24,6 +24,9 @@
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b0\u09be\u09ae\u09cd\u09ac\u09bf\u0993 \u09ac\u09c7\u09b8"
     ],
+    "name:cat_x_preferred":[
+        "estaci\u00f3 Marambio"
+    ],
     "name:ceb_x_preferred":[
         "Marambio Base"
     ],
@@ -39,6 +42,9 @@
     "name:eng_x_preferred":[
         "Marambio Base"
     ],
+    "name:eng_x_variant":[
+        "Marambio Station"
+    ],
     "name:fas_x_preferred":[
         "\u067e\u0627\u06cc\u06af\u0627\u0647 \u0647\u0648\u0627\u06cc\u06cc \u0645\u0627\u0631\u0627\u0645\u0628\u06cc\u0648"
     ],
@@ -46,7 +52,8 @@
         "base antarctique Marambio"
     ],
     "name:fra_x_variant":[
-        "Vicecomodoro Marambio"
+        "Vicecomodoro Marambio",
+        "station du Vicecomodoro Marambio"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05e1\u05d9\u05e1 \u05de\u05e8\u05de\u05d1\u05d9\u05d5"
@@ -72,6 +79,9 @@
     "name:lav_x_preferred":[
         "Marambio"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u041c\u0430\u0440\u0430\u043c\u0431\u0438\u043e\u201c"
+    ],
     "name:nld_x_preferred":[
         "Marambio Base"
     ],
@@ -91,7 +101,8 @@
         "Base Marambio"
     ],
     "name:spa_x_variant":[
-        "Vicecomodoro Marambio"
+        "Vicecomodoro Marambio",
+        "Estaci\u00f3n Marambio"
     ],
     "name:swe_x_preferred":[
         "Marambio"
@@ -226,7 +237,7 @@
         }
     ],
     "wof:id":1141908395,
-    "wof:lastmodified":1636502611,
+    "wof:lastmodified":1690850375,
     "wof:name":"Marambio Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/839/7/1141908397.geojson
+++ b/data/114/190/839/7/1141908397.geojson
@@ -45,6 +45,9 @@
     "name:fra_x_preferred":[
         "station Mario Zucchelli"
     ],
+    "name:fra_x_variant":[
+        "Base antarctique Mario-Zucchelli"
+    ],
     "name:heb_x_preferred":[
         "\u05ea\u05d7\u05e0\u05ea \u05d6\u05d5\u05e6'\u05dc\u05d9"
     ],
@@ -62,6 +65,9 @@
     ],
     "name:jpn_x_preferred":[
         "Mario Zucchelli\u57fa\u5730"
+    ],
+    "name:jpn_x_variant":[
+        "\u30de\u30ea\u30aa\u30fb\u30ba\u30c3\u30b1\u30ea\u57fa\u5730"
     ],
     "name:kor_x_preferred":[
         "\uc8fc\uccbc\ub9ac \uc2a4\ud14c\uc774\uc158"
@@ -104,6 +110,9 @@
     ],
     "name:vie_x_preferred":[
         "Tr\u1ea1m Zucchelli"
+    ],
+    "name:zho_x_preferred":[
+        "\u9a6c\u91cc\u5965\u00b7\u7956\u5207\u5229\u7ad9"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Antarctica",
@@ -220,7 +229,7 @@
         }
     ],
     "wof:id":1141908397,
-    "wof:lastmodified":1636502611,
+    "wof:lastmodified":1690850375,
     "wof:name":"Zucchelli Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/840/9/1141908409.geojson
+++ b/data/114/190/840/9/1141908409.geojson
@@ -27,6 +27,9 @@
     "name:ben_x_preferred":[
         "\u0995\u09bf\u0982 \u09b8\u09c7\u099c\u0982 \u09b8\u09cd\u099f\u09c7\u09b6\u09a8"
     ],
+    "name:cat_x_preferred":[
+        "Base Rei Sejong"
+    ],
     "name:ceb_x_preferred":[
         "King Sejong Station"
     ],
@@ -38,6 +41,9 @@
     ],
     "name:eng_x_preferred":[
         "King Sejong Station"
+    ],
+    "name:fas_x_preferred":[
+        "\u0627\u06cc\u0633\u062a\u06af\u0627\u0647 \u0633\u062c\u0648\u0646\u06af \u06a9\u0628\u06cc\u0631"
     ],
     "name:fra_x_preferred":[
         "base antarctique du roi Sejong"
@@ -80,6 +86,9 @@
     ],
     "name:pol_x_preferred":[
         "King Sejong"
+    ],
+    "name:por_x_preferred":[
+        "Esta\u00e7\u00e3o Rei Sejong"
     ],
     "name:rus_x_preferred":[
         "\u041a\u0438\u043d\u0433-\u0421\u0435\u0434\u0436\u043e\u043d\u0433"
@@ -234,7 +243,7 @@
         }
     ],
     "wof:id":1141908409,
-    "wof:lastmodified":1636502610,
+    "wof:lastmodified":1690850375,
     "wof:name":"King Sejong Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/841/1/1141908411.geojson
+++ b/data/114/190/841/1/1141908411.geojson
@@ -69,6 +69,9 @@
     "name:lav_x_preferred":[
         "\u010can\u010dena"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0442\u0430\u043d\u0438\u0446\u0430 \u201e\u0410\u043d\u0442\u0430\u0440\u043a\u0442\u0438\u0447\u043a\u0438 \u0413\u043e\u043b\u0435\u043c \u0405\u0438\u0434\u201c"
+    ],
     "name:nld_x_preferred":[
         "Antarctic Great Wall Station"
     ],
@@ -95,6 +98,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0ba3\u0bcd\u0b9f\u0bbe\u0bb0\u0bcd\u0b95\u0bcd\u0b9f\u0bbf\u0b95\u0bcd\u0b95\u0bbe \u0baa\u0bc6\u0bb0\u0bc1\u0b9e\u0bcd\u0b9a\u0bc1\u0bb5\u0bb0\u0bcd \u0b86\u0baf\u0bcd\u0bb5\u0bc1\u0b95\u0bcd\u0b95\u0bc2\u0b9f\u0bae\u0bcd"
+    ],
+    "name:tur_x_preferred":[
+        "\u00c7in Seddi \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u0412\u0435\u043b\u0438\u043a\u0430 \u0441\u0442\u0456\u043d\u0430"
@@ -223,7 +229,7 @@
         }
     ],
     "wof:id":1141908411,
-    "wof:lastmodified":1636502609,
+    "wof:lastmodified":1690850373,
     "wof:name":"Great Wall Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/841/9/1141908419.geojson
+++ b/data/114/190/841/9/1141908419.geojson
@@ -75,6 +75,9 @@
     "name:lav_x_preferred":[
         "Skota"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u0421\u043a\u043e\u0442\u201c"
+    ],
     "name:mon_x_preferred":[
         "\u0421\u043a\u043e\u0442\u0442 \u0431\u0430\u0430\u0437"
     ],
@@ -235,7 +238,7 @@
         }
     ],
     "wof:id":1141908419,
-    "wof:lastmodified":1636502608,
+    "wof:lastmodified":1690850373,
     "wof:name":"Scott Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/842/3/1141908423.geojson
+++ b/data/114/190/842/3/1141908423.geojson
@@ -78,6 +78,9 @@
     "name:pol_x_preferred":[
         "Zhongshan"
     ],
+    "name:por_x_preferred":[
+        "Esta\u00e7\u00e3o Ant\u00e1rtica Zhongshan"
+    ],
     "name:rus_x_preferred":[
         "\u0427\u0436\u0443\u043d\u0448\u0430\u043d\u044c"
     ],
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":1141908423,
-    "wof:lastmodified":1636502607,
+    "wof:lastmodified":1690850372,
     "wof:name":"Zhongshan Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/843/1/1141908431.geojson
+++ b/data/114/190/843/1/1141908431.geojson
@@ -30,6 +30,9 @@
     "name:ceb_x_preferred":[
         "Mawson"
     ],
+    "name:dan_x_preferred":[
+        "Mawson Station"
+    ],
     "name:deu_x_preferred":[
         "Mawson-Station"
     ],
@@ -102,6 +105,9 @@
     "name:swe_x_preferred":[
         "Mawson Station"
     ],
+    "name:tur_x_preferred":[
+        "Mawson \u0130stasyonu"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u043e\u0443\u0441\u043e\u043d"
     ],
@@ -110,6 +116,9 @@
     ],
     "name:vie_x_preferred":[
         "Tr\u1ea1m Mawson"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10db\u10dd\u10e3\u10e1\u10dd\u10dc\u10d8"
     ],
     "name:zho_x_preferred":[
         "\u83ab\u68ee\u7ad9"
@@ -229,7 +238,7 @@
         }
     ],
     "wof:id":1141908431,
-    "wof:lastmodified":1636502607,
+    "wof:lastmodified":1690850373,
     "wof:name":"Mawson Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/843/9/1141908439.geojson
+++ b/data/114/190/843/9/1141908439.geojson
@@ -18,6 +18,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:ara_x_preferred":[
+        "\u0645\u062d\u0637\u0629 \u0643\u0627\u0633\u064a"
+    ],
     "name:ast_x_preferred":[
         "Base Casey"
     ],
@@ -66,6 +69,9 @@
     "name:lav_x_preferred":[
         "Keisi"
     ],
+    "name:lit_x_preferred":[
+        "Keisio stotis"
+    ],
     "name:min_x_preferred":[
         "Taksiun Casey"
     ],
@@ -92,6 +98,9 @@
     ],
     "name:swe_x_preferred":[
         "Casey"
+    ],
+    "name:tur_x_preferred":[
+        "Casey \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u041a\u0435\u0439\u0441\u0456"
@@ -220,7 +229,7 @@
         }
     ],
     "wof:id":1141908439,
-    "wof:lastmodified":1636502607,
+    "wof:lastmodified":1690850373,
     "wof:name":"Casey Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/845/5/1141908455.geojson
+++ b/data/114/190/845/5/1141908455.geojson
@@ -27,6 +27,9 @@
     "name:ben_x_preferred":[
         "\u09ae\u09c8\u09a4\u09cd\u09b0\u09c0 \u0985\u09a8\u09c1\u09b8\u09a8\u09cd\u09a7\u09be\u09a8 \u0995\u09c7\u09a8\u09cd\u09a6\u09cd\u09b0"
     ],
+    "name:cat_x_preferred":[
+        "Base Maitri"
+    ],
     "name:ceb_x_preferred":[
         "Maitri Station"
     ],
@@ -35,6 +38,9 @@
     ],
     "name:deu_x_preferred":[
         "Maitri Station"
+    ],
+    "name:deu_x_variant":[
+        "Maitri-Station"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03b1\u0390\u03c4\u03c1\u03b9 \u03a3\u03c4\u03ad\u03b9\u03c3\u03b9\u03bf\u03bd"
@@ -114,6 +120,9 @@
     ],
     "name:swe_x_preferred":[
         "Maitri"
+    ],
+    "name:tel_x_preferred":[
+        "\u0c2e\u0c48\u0c24\u0c4d\u0c30\u0c3f"
     ],
     "name:tur_x_preferred":[
         "Maitri \u0130stasyonu"
@@ -259,7 +268,7 @@
         }
     ],
     "wof:id":1141908455,
-    "wof:lastmodified":1636502606,
+    "wof:lastmodified":1690850372,
     "wof:name":"Maitri Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/845/9/1141908459.geojson
+++ b/data/114/190/845/9/1141908459.geojson
@@ -24,8 +24,17 @@
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09b2\u0997\u09cd\u09b0\u09cd\u09af\u09be\u09a8\u09cb II \u09ac\u09c7\u09b8"
     ],
+    "name:cat_x_preferred":[
+        "Base Belgrano"
+    ],
     "name:ceb_x_preferred":[
         "Belgrano II"
+    ],
+    "name:ceb_x_variant":[
+        "Belgrano"
+    ],
+    "name:deu_x_preferred":[
+        "Belgrano-II-Station"
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03b5\u03bb\u03b3\u03ba\u03c1\u03ac\u03bd\u03bf \u0399\u0399 \u039c\u03c0\u03ad\u03b9\u03c2"
@@ -39,8 +48,14 @@
     "name:fin_x_preferred":[
         "General Belgrano II"
     ],
+    "name:fin_x_variant":[
+        "General Belgrano"
+    ],
     "name:fra_x_preferred":[
         "base antarctique Belgrano II"
+    ],
+    "name:fra_x_variant":[
+        "base antarctique Belgrano-II"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05e1\u05d9\u05e1 \u05d1\u05dc\u05d2\u05e8\u05e0\u05d5 II"
@@ -57,6 +72,9 @@
     "name:ita_x_preferred":[
         "Base dell'esercito generale Belgrano II"
     ],
+    "name:ita_x_variant":[
+        "Base dell'esercito generale Belgrano"
+    ],
     "name:jpn_x_preferred":[
         "\u3078\u30cd\u30e9\u30eb\u30fb\u30d9\u30eb\u30b0\u30e9\u30ceII\u57fa\u5730"
     ],
@@ -66,8 +84,17 @@
     "name:lav_x_preferred":[
         "Belgrano II"
     ],
+    "name:lav_x_variant":[
+        "Belgrano"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u0411\u0435\u043b\u0433\u0440\u0430\u043d\u043e"
+    ],
     "name:nld_x_preferred":[
         "General Belgrano II"
+    ],
+    "name:nld_x_variant":[
+        "General Belgrano"
     ],
     "name:nno_x_preferred":[
         "Belgrano II-basen"
@@ -75,20 +102,38 @@
     "name:nob_x_preferred":[
         "Belgrano II"
     ],
+    "name:nob_x_variant":[
+        "Belgrano"
+    ],
     "name:pol_x_preferred":[
         "Belgrano II"
+    ],
+    "name:pol_x_variant":[
+        "Belgrano"
     ],
     "name:por_x_preferred":[
         "Base Belgrano II"
     ],
+    "name:por_x_variant":[
+        "Base Belgrano"
+    ],
     "name:rus_x_preferred":[
         "\u0411\u0435\u043b\u044c\u0433\u0440\u0430\u043d\u043e II"
+    ],
+    "name:rus_x_variant":[
+        "\u0411\u0435\u043b\u044c\u0433\u0440\u0430\u043d\u043e"
     ],
     "name:spa_x_preferred":[
         "Base Belgrano II"
     ],
+    "name:spa_x_variant":[
+        "Base Belgrano"
+    ],
     "name:swe_x_preferred":[
         "Belgrano II"
+    ],
+    "name:swe_x_variant":[
+        "Belgrano"
     ],
     "name:tur_x_preferred":[
         "Belgrano II \u00dcss\u00fc"
@@ -96,11 +141,17 @@
     "name:ukr_x_preferred":[
         "\u0411\u0435\u043b\u044c\u0491\u0440\u0430\u043d\u043e II"
     ],
+    "name:ukr_x_variant":[
+        "\u0411\u0435\u043b\u044c\u0491\u0440\u0430\u043d\u043e"
+    ],
     "name:urd_x_preferred":[
         "\u0628\u06cc\u0644\u06af\u0631\u0627\u0646\u0648 II \u0628\u06cc\u0633"
     ],
     "name:vie_x_preferred":[
         "C\u0103n c\u1ee9 Belgrano II"
+    ],
+    "name:zho_x_preferred":[
+        "\u8d1d\u5c14\u683c\u62c9\u8bfa\u4e8c\u53f7\u7ad9"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Antarctica",
@@ -217,7 +268,7 @@
         }
     ],
     "wof:id":1141908459,
-    "wof:lastmodified":1636502606,
+    "wof:lastmodified":1690850372,
     "wof:name":"Belgrano II Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/846/5/1141908465.geojson
+++ b/data/114/190/846/5/1141908465.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"-67.099997601,-68.1163215956,-67.099997601,-68.1163215956",
+    "geom:bbox":"-67.099998,-68.116322,-67.099998,-68.116322",
     "geom:latitude":-68.116322,
     "geom:longitude":-67.099998,
     "iso:country":"AQ",
@@ -18,14 +18,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:cat_x_preferred":[
+        "Base San Mart\u00edn"
+    ],
     "name:ceb_x_preferred":[
         "San Mart\u00edn Station"
+    ],
+    "name:deu_x_preferred":[
+        "General-San-Martin-Station"
     ],
     "name:eng_x_preferred":[
         "San Mart\u00edn Base"
     ],
     "name:fra_x_preferred":[
         "base antarctique San Mart\u00edn"
+    ],
+    "name:fra_x_variant":[
+        "base antarctique San-Mart\u00edn"
     ],
     "name:hun_x_preferred":[
         "San Mart\u00edn kutat\u00f3\u00e1llom\u00e1s"
@@ -35,6 +44,9 @@
     ],
     "name:lav_x_preferred":[
         "Sanmartina"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u0421\u0430\u043d \u041c\u0430\u0440\u0442\u0438\u043d\u201c"
     ],
     "name:nld_x_preferred":[
         "San Mart\u00edn basis"
@@ -169,7 +181,7 @@
     },
     "wof:country":"AQ",
     "wof:created":1499130907,
-    "wof:geomhash":"8a62d60d032bbdca56d12158552fe46c",
+    "wof:geomhash":"46737e1d63fe21073a713853d78e4110",
     "wof:hierarchy":[
         {
             "continent_id":102191579,
@@ -178,7 +190,7 @@
         }
     ],
     "wof:id":1141908465,
-    "wof:lastmodified":1566587529,
+    "wof:lastmodified":1690850374,
     "wof:name":"San Martin Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
@@ -188,10 +200,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -67.09999760096696,
-    -68.11632159563368,
-    -67.09999760096696,
-    -68.11632159563368
+    -67.099998,
+    -68.116322,
+    -67.099998,
+    -68.116322
 ],
-  "geometry": {"coordinates":[-67.09999760096696,-68.11632159563368],"type":"Point"}
+  "geometry": {"coordinates":[-67.099998,-68.116322],"type":"Point"}
 }

--- a/data/114/190/847/5/1141908475.geojson
+++ b/data/114/190/847/5/1141908475.geojson
@@ -63,6 +63,9 @@
     "name:lav_x_preferred":[
         "Signi"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0438\u0433\u043d\u0438"
+    ],
     "name:nld_x_preferred":[
         "Signy Research Station"
     ],
@@ -217,7 +220,7 @@
         }
     ],
     "wof:id":1141908475,
-    "wof:lastmodified":1636502610,
+    "wof:lastmodified":1690850374,
     "wof:name":"Signy Research Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/848/1/1141908481.geojson
+++ b/data/114/190/848/1/1141908481.geojson
@@ -78,6 +78,9 @@
     "name:lit_x_preferred":[
         "Dumont d'Urville stotis"
     ],
+    "name:mkd_x_preferred":[
+        "\u0414\u0438\u043c\u043e\u043d \u0414\u0438\u0440\u0432\u0438\u043b"
+    ],
     "name:nld_x_preferred":[
         "Station Dumont d'Urville"
     ],
@@ -104,6 +107,9 @@
     ],
     "name:swe_x_preferred":[
         "Dumont d'Urville"
+    ],
+    "name:tur_x_preferred":[
+        "Dumont d'Urville \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u0414\u044e\u043c\u043e\u043d \u0414\u044e\u0440\u0432\u0456\u043b\u044c"
@@ -232,7 +238,7 @@
         }
     ],
     "wof:id":1141908481,
-    "wof:lastmodified":1636502610,
+    "wof:lastmodified":1690850374,
     "wof:name":"Dumont d'Urville Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/114/190/848/3/1141908483.geojson
+++ b/data/114/190/848/3/1141908483.geojson
@@ -42,6 +42,9 @@
     "name:eng_x_preferred":[
         "Showa Station"
     ],
+    "name:epo_x_preferred":[
+        "Stacio Showa"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u06cc\u0633\u062a\u06af\u0627\u0647 \u0634\u0648\u0627"
     ],
@@ -101,6 +104,9 @@
     ],
     "name:swe_x_preferred":[
         "Syowa"
+    ],
+    "name:tur_x_preferred":[
+        "Sh\u014dwa \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u044c\u043e\u0432\u0430"
@@ -229,7 +235,7 @@
         }
     ],
     "wof:id":1141908483,
-    "wof:lastmodified":1636502610,
+    "wof:lastmodified":1690850374,
     "wof:name":"Showa Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/327/15/85632715.geojson
+++ b/data/856/327/15/85632715.geojson
@@ -715,6 +715,9 @@
     "name:tir_x_preferred":[
         "\u12a0\u1295\u1273\u122d\u12ad\u1272\u12ab"
     ],
+    "name:tok_x_preferred":[
+        "ma Antasika"
+    ],
     "name:ton_x_preferred":[
         "\u02bbAnet\u0101tika"
     ],
@@ -1021,7 +1024,7 @@
         }
     ],
     "wof:id":85632715,
-    "wof:lastmodified":1636502604,
+    "wof:lastmodified":1690850367,
     "wof:name":"Antarctica",
     "wof:parent_id":102191579,
     "wof:placetype":"country",

--- a/data/890/421/517/890421517.geojson
+++ b/data/890/421/517/890421517.geojson
@@ -82,6 +82,9 @@
     "name:lit_x_preferred":[
         "Dumont d'Urville stotis"
     ],
+    "name:mkd_x_preferred":[
+        "\u0414\u0438\u043c\u043e\u043d \u0414\u0438\u0440\u0432\u0438\u043b"
+    ],
     "name:nld_x_preferred":[
         "Station Dumont d'Urville"
     ],
@@ -257,7 +260,7 @@
         }
     ],
     "wof:id":890421517,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850368,
     "wof:name":"Dumont d'Urville Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/421/519/890421519.geojson
+++ b/data/890/421/519/890421519.geojson
@@ -25,6 +25,9 @@
     "name:ceb_x_preferred":[
         "Base Presidente Eduardo Frei Montalva"
     ],
+    "name:deu_x_preferred":[
+        "Base Presidente Eduardo Frei Montalva"
+    ],
     "name:eng_x_preferred":[
         "Eduardo Frei Montalva (Chile)"
     ],
@@ -49,6 +52,9 @@
     ],
     "name:lav_x_preferred":[
         "Eduardofreja"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u041f\u0440\u0435\u0442\u0441\u0435\u0434\u0430\u0442\u0435\u043b \u0415\u0434\u0443\u0430\u0440\u0434\u043e \u0424\u0440\u0435\u0458 \u041c\u043e\u043d\u0442\u0430\u043b\u0432\u0430\u201c"
     ],
     "name:nld_x_preferred":[
         "Presidente Eduardo Frei Montalva Station"
@@ -83,6 +89,9 @@
     ],
     "name:tgk_x_preferred":[
         "\u041f\u043e\u0439\u0433\u043e\u04b3\u0438 \u0440\u0430\u0435\u0441\u200c\u04b7\u0443\u043c\u04b3\u0443\u0440\u0438 \u0438\u0434\u0432\u043e\u0440\u0434\u0443 \u0444\u0430\u0440 \u043c\u0443\u043d\u0442\u043e\u043b\u0443\u043e"
+    ],
+    "name:tur_x_preferred":[
+        "Presidente Eduardo Frei Montalva \u00dcss\u00fc"
     ],
     "name:ukr_x_preferred":[
         "\u0424\u0440\u0435\u0439"
@@ -120,7 +129,7 @@
         }
     ],
     "wof:id":890421519,
-    "wof:lastmodified":1566587523,
+    "wof:lastmodified":1690850369,
     "wof:name":"Eduardo Frei Montalva",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/421/521/890421521.geojson
+++ b/data/890/421/521/890421521.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":6.1,
+    "name:ara_x_preferred":[
+        "\u0645\u062d\u0637\u0629 \u0623\u0628\u062d\u0627\u062b \u0647\u0627\u0644\u064a"
+    ],
     "name:ast_x_preferred":[
         "Base Halley"
     ],
@@ -64,6 +67,9 @@
     "name:lit_x_preferred":[
         "Heilio stotis"
     ],
+    "name:mkd_x_preferred":[
+        "\u0425\u0430\u043b\u0435\u0458"
+    ],
     "name:nld_x_preferred":[
         "Halley Research Station"
     ],
@@ -93,6 +99,9 @@
     ],
     "name:swe_x_preferred":[
         "Halley Research Station"
+    ],
+    "name:tur_x_preferred":[
+        "Halley Ara\u015ft\u0131rma \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u0413\u0430\u043b\u043b\u0435\u0439"
@@ -224,7 +233,7 @@
         }
     ],
     "wof:id":890421521,
-    "wof:lastmodified":1582356322,
+    "wof:lastmodified":1690850369,
     "wof:name":"Halley Research Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/424/159/890424159.geojson
+++ b/data/890/424/159/890424159.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:afr_x_preferred":[
+        "McMurdo-stasie"
+    ],
     "name:ara_x_preferred":[
         "\u0642\u0627\u0639\u062f\u0629 \u0645\u0627\u0643 \u0645\u0648\u0631\u062f\u0648"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:epo_x_preferred":[
         "Polusa stacio McMurdo"
+    ],
+    "name:est_x_preferred":[
+        "McMurdo polaarjaam"
     ],
     "name:eus_x_preferred":[
         "McMurdo basea"
@@ -160,6 +166,9 @@
     "name:vie_x_preferred":[
         "Tr\u1ea1m McMurdo"
     ],
+    "name:yue_x_preferred":[
+        "\u9ea5\u514b\u9ed8\u591a\u7ad9"
+    ],
     "name:zho_x_preferred":[
         "\u9ea5\u514b\u9ed8\u591a\u7ad9"
     ],
@@ -197,7 +206,7 @@
         }
     ],
     "wof:id":890424159,
-    "wof:lastmodified":1636502604,
+    "wof:lastmodified":1690850367,
     "wof:name":"McMurdo Station",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/435/319/890435319.geojson
+++ b/data/890/435/319/890435319.geojson
@@ -55,6 +55,9 @@
     "name:lav_x_preferred":[
         "Novolazarevska"
     ],
+    "name:mkd_x_preferred":[
+        "\u041d\u043e\u0432\u043e\u043b\u0430\u0437\u0430\u0440\u0435\u0432\u0441\u043a\u0430\u0458\u0430 \u0441\u0442\u0430\u043d\u0438\u0446\u0430"
+    ],
     "name:nld_x_preferred":[
         "Novolazarevskaja"
     ],
@@ -84,6 +87,9 @@
     ],
     "name:swe_x_preferred":[
         "Novolazarevskaja"
+    ],
+    "name:tur_x_preferred":[
+        "Novolazarevskaya \u0130stasyonu"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0442\u0430\u043d\u0446\u0456\u044f \u041d\u043e\u0432\u043e\u043b\u0430\u0437\u0430\u0440\u0435\u0432\u0441\u044c\u043a\u0430"
@@ -230,7 +236,7 @@
         }
     ],
     "wof:id":890435319,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850370,
     "wof:name":"Novolazarevskaya Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/327/890435327.geojson
+++ b/data/890/435/327/890435327.geojson
@@ -29,7 +29,8 @@
         "Orcadas Base (Argentina)"
     ],
     "name:eng_x_variant":[
-        "Orcadas Base"
+        "Orcadas Base",
+        "Orcadas Station"
     ],
     "name:epo_x_preferred":[
         "Stacio Orcadas"
@@ -40,6 +41,9 @@
     "name:fra_x_preferred":[
         "base antarctique Orcadas"
     ],
+    "name:heb_x_preferred":[
+        "\u05ea\u05d7\u05e0\u05ea \u05d4\u05d7\u05d9\u05d6\u05d5\u05d9 \u05d0\u05d5\u05e8\u05e7\u05d3\u05d0\u05e1"
+    ],
     "name:hun_x_preferred":[
         "Orcadas kutat\u00f3\u00e1llom\u00e1s"
     ],
@@ -49,8 +53,14 @@
     "name:ita_x_preferred":[
         "Distaccamento navale Orcadas"
     ],
+    "name:jpn_x_preferred":[
+        "\u30aa\u30eb\u30ab\u30c0\u30b9\u57fa\u5730"
+    ],
     "name:lav_x_preferred":[
         "Orkadasa"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u041e\u0440\u043a\u0430\u0434\u0430\u0441\u201c"
     ],
     "name:nld_x_preferred":[
         "Orcadas Base"
@@ -82,8 +92,14 @@
     "name:spa_x_preferred":[
         "Base Orcadas"
     ],
+    "name:spa_x_variant":[
+        "Estaci\u00f3n Orcadas"
+    ],
     "name:swe_x_preferred":[
         "Orcadas"
+    ],
+    "name:tur_x_preferred":[
+        "Orcadas \u00dcss\u00fc"
     ],
     "name:ukr_x_preferred":[
         "\u041e\u0440\u043a\u0430\u0434\u0430\u0441"
@@ -121,7 +137,7 @@
         }
     ],
     "wof:id":890435327,
-    "wof:lastmodified":1566587523,
+    "wof:lastmodified":1690850369,
     "wof:name":"Orcadas Base",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/435/329/890435329.geojson
+++ b/data/890/435/329/890435329.geojson
@@ -73,6 +73,9 @@
     "name:lav_x_preferred":[
         "P\u0101lmera"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0442\u0430\u043d\u0438\u0446\u0430 \u201e\u041f\u0430\u043b\u043c\u0435\u0440\u201c"
+    ],
     "name:nld_x_preferred":[
         "Palmer Station"
     ],
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":890435329,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850370,
     "wof:name":"Palmer Station",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/435/337/890435337.geojson
+++ b/data/890/435/337/890435337.geojson
@@ -40,6 +40,9 @@
     "name:eng_x_variant":[
         "Concordia Station"
     ],
+    "name:est_x_preferred":[
+        "Concordia"
+    ],
     "name:eus_x_preferred":[
         "Concordia basea"
     ],
@@ -57,6 +60,9 @@
     ],
     "name:lav_x_preferred":[
         "Konkordija"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041a\u043e\u043d\u043a\u043e\u0440\u0434\u0438\u0458\u0430"
     ],
     "name:nld_x_preferred":[
         "Concordia Station"
@@ -88,11 +94,17 @@
     "name:swe_x_preferred":[
         "Concordia"
     ],
+    "name:tur_x_preferred":[
+        "Concordia \u0130stasyonu"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u043d\u043a\u043e\u0440\u0434\u0456\u044f"
     ],
     "name:urd_x_preferred":[
         "\u06a9\u0646\u06a9\u0648\u0631\u0688\u06cc\u0627 \u0627\u0633\u0679\u06cc\u0634\u0646"
+    ],
+    "name:uzb_x_preferred":[
+        "Concordia"
     ],
     "name:zho_x_preferred":[
         "\u5eb7\u5b8f\u7ad9"
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":890435337,
-    "wof:lastmodified":1566587523,
+    "wof:lastmodified":1690850369,
     "wof:name":"Concordia Station",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/438/223/890438223.geojson
+++ b/data/890/438/223/890438223.geojson
@@ -37,6 +37,9 @@
     "name:ces_x_preferred":[
         "Pol\u00e1rn\u00ed stanice Amundsen-Scott"
     ],
+    "name:ces_x_variant":[
+        "Pol\u00e1rn\u00ed stanice Amundsen\u2013Scott"
+    ],
     "name:cym_x_preferred":[
         "Arsyllfa Amundsen\u2013Scott ym Mhegwn y De"
     ],
@@ -142,6 +145,9 @@
     "name:tur_x_preferred":[
         "Amundsen-Scott G\u00fcney Kutbu \u0130stasyonu"
     ],
+    "name:vie_x_preferred":[
+        "Tr\u1ea1m Nam C\u1ef1c Amundsen-Scott"
+    ],
     "qs:name":"Amundsen-Scott South Pole Station",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -172,7 +178,7 @@
         }
     ],
     "wof:id":890438223,
-    "wof:lastmodified":1566587522,
+    "wof:lastmodified":1690850368,
     "wof:name":"Amundsen-Scott South Pole Station",
     "wof:parent_id":85681139,
     "wof:placetype":"locality",

--- a/data/890/439/875/890439875.geojson
+++ b/data/890/439/875/890439875.geojson
@@ -53,6 +53,9 @@
     "name:lij_x_preferred":[
         "B\u00e2ze Carlini"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u041a\u0430\u0440\u043b\u0438\u043d\u0438\u201c"
+    ],
     "name:nld_x_preferred":[
         "Carlini Station"
     ],
@@ -73,6 +76,9 @@
     ],
     "name:por_x_preferred":[
         "Jubany"
+    ],
+    "name:rus_x_preferred":[
+        "\u041a\u0430\u0440\u043b\u0438\u043d\u0438"
     ],
     "name:spa_x_preferred":[
         "Base Carlini"
@@ -107,7 +113,7 @@
         }
     ],
     "wof:id":890439875,
-    "wof:lastmodified":1566587522,
+    "wof:lastmodified":1690850368,
     "wof:name":"Jubany",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/442/033/890442033.geojson
+++ b/data/890/442/033/890442033.geojson
@@ -79,6 +79,9 @@
     "name:lav_x_preferred":[
         "Skota"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0437\u0430 \u201e\u0421\u043a\u043e\u0442\u201c"
+    ],
     "name:mon_x_preferred":[
         "\u0421\u043a\u043e\u0442\u0442 \u0431\u0430\u0430\u0437"
     ],
@@ -257,7 +260,7 @@
         }
     ],
     "wof:id":890442033,
-    "wof:lastmodified":1636502605,
+    "wof:lastmodified":1690850369,
     "wof:name":"Scott Base",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.