### PR TITLE
aq concordances, placetype local, and more

### DIFF
--- a/data/856/327/15/85632715.geojson
+++ b/data/856/327/15/85632715.geojson
@@ -1006,6 +1006,7 @@
         "gn:id":6697173,
         "gp:id":28289409,
         "hasc:id":"AQ",
+        "iso:code":"AQ",
         "m49:code":"010",
         "marc:id":"ay",
         "ne:adm0_a3":"ATA",
@@ -1014,6 +1015,7 @@
         "wd:id":"Q21590062",
         "wmo:id":"AA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AQ",
     "wof:country_alpha3":"ATA",
     "wof:geom_alt":[
@@ -1028,7 +1030,7 @@
         }
     ],
     "wof:id":85632715,
-    "wof:lastmodified":1694639669,
+    "wof:lastmodified":1695881328,
     "wof:name":"Antarctica",
     "wof:parent_id":102191579,
     "wof:placetype":"country",

--- a/data/856/811/47/85681147.geojson
+++ b/data/856/811/47/85681147.geojson
@@ -59,7 +59,7 @@
         }
     ],
     "wof:id":85681147,
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884282,
     "wof:name":"Minor islands of Antarctica",
     "wof:parent_id":85632715,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.